### PR TITLE
feat: 도시 상세 페이지 구현 (#1)

### DIFF
--- a/__tests__/components/cities/CityCard.test.tsx
+++ b/__tests__/components/cities/CityCard.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: any) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/ui/card", () => ({
+  Card: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...props }: any) => <span {...props}>{children}</span>,
+}));
+
+vi.mock("@/components/cities/CityAsciiArt", () => ({
+  default: () => <div data-testid="city-ascii-art" />,
+}));
+
+vi.mock("lucide-react", () => ({
+  ThumbsUp: ({ size, ...props }: { size?: number }) => (
+    <span data-testid="thumbs-up" {...props} />
+  ),
+  ThumbsDown: ({ size, ...props }: { size?: number }) => (
+    <span data-testid="thumbs-down" {...props} />
+  ),
+}));
+
+import CityCard from "@/components/cities/CityCard";
+import { City } from "@/lib/data";
+
+const mockCity: City = {
+  id: "jeju",
+  rank: 1,
+  name: "제주시",
+  nameEn: "JEJU",
+  region: "제주도",
+  score: 8.5,
+  monthlyCost: 1580000,
+  monthlyRent: 550000,
+  metrics: { internet: 8.2, cafe: 9.0, transport: 7.5, nature: 9.8, nomadFriendly: 9.2 },
+  tags: ["바다", "자연", "감성카페"],
+  environment: ["자연친화", "카페작업"],
+  budget: "100~200만원",
+  season: ["봄", "가을"],
+  likes: 128,
+  dislikes: 12,
+  internetSpeed: 82,
+  weather: "맑음 18°C",
+  aqi: 32,
+  symbol: "★",
+  mapX: 28,
+  mapY: 82,
+};
+
+describe("CityCard", () => {
+  const defaultProps = {
+    city: mockCity,
+    rank: 1,
+    liked: false,
+    disliked: false,
+    likes: 128,
+    dislikes: 12,
+    onLike: vi.fn(),
+    onDislike: vi.fn(),
+    onReview: vi.fn(),
+  };
+
+  // 1. Link가 /cities/{city.id}로 렌더링되는지
+  it("renders Link with correct href /cities/{city.id}", () => {
+    render(<CityCard {...defaultProps} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/cities/jeju");
+  });
+
+  // 2. 도시명, 영문명, 지역이 표시되는지
+  it("displays city name, English name, and region", () => {
+    render(<CityCard {...defaultProps} />);
+
+    expect(screen.getByText("제주시")).toBeInTheDocument();
+    expect(screen.getByText(/JEJU/)).toBeInTheDocument();
+    // "제주도"는 서브타이틀과 정보 필드 두 곳에 표시됨
+    const regionElements = screen.getAllByText(/제주도/);
+    expect(regionElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // 3. 태그가 모두 렌더링되는지
+  it("renders all tags", () => {
+    render(<CityCard {...defaultProps} />);
+
+    expect(screen.getByText("바다")).toBeInTheDocument();
+    expect(screen.getByText("자연")).toBeInTheDocument();
+    expect(screen.getByText("감성카페")).toBeInTheDocument();
+  });
+
+  // 4. 좋아요/싫어요 수가 표시되는지
+  it("displays likes and dislikes counts", () => {
+    render(<CityCard {...defaultProps} />);
+
+    expect(screen.getByText("128")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+  });
+
+  // 5. 좋아요 버튼 클릭 시 onLike가 호출되는지
+  it("calls onLike with city id when like button is clicked", () => {
+    const onLike = vi.fn();
+    render(<CityCard {...defaultProps} onLike={onLike} />);
+
+    const likeButton = screen.getByText("128").closest("button")!;
+    fireEvent.click(likeButton);
+
+    expect(onLike).toHaveBeenCalledWith("jeju");
+    expect(onLike).toHaveBeenCalledTimes(1);
+  });
+
+  // 6. 싫어요 버튼 클릭 시 onDislike가 호출되는지
+  it("calls onDislike with city id when dislike button is clicked", () => {
+    const onDislike = vi.fn();
+    render(<CityCard {...defaultProps} onDislike={onDislike} />);
+
+    const dislikeButton = screen.getByText("12").closest("button")!;
+    fireEvent.click(dislikeButton);
+
+    expect(onDislike).toHaveBeenCalledWith("jeju");
+    expect(onDislike).toHaveBeenCalledTimes(1);
+  });
+
+  // 7. 리뷰 버튼 클릭 시 onReview가 호출되는지
+  it("calls onReview with city id when review button is clicked", () => {
+    const onReview = vi.fn();
+    render(<CityCard {...defaultProps} onReview={onReview} />);
+
+    const reviewButton = screen.getByText(/리뷰/).closest("button")!;
+    fireEvent.click(reviewButton);
+
+    expect(onReview).toHaveBeenCalledWith("jeju");
+    expect(onReview).toHaveBeenCalledTimes(1);
+  });
+
+  // 8. 버튼 클릭 시 stopPropagation과 preventDefault가 호출되는지
+  it("calls stopPropagation and preventDefault on button clicks", () => {
+    render(<CityCard {...defaultProps} />);
+
+    const likeButton = screen.getByText("128").closest("button")!;
+    const clickEvent = new MouseEvent("click", { bubbles: true, cancelable: true });
+    const preventDefaultSpy = vi.spyOn(clickEvent, "preventDefault");
+    const stopPropagationSpy = vi.spyOn(clickEvent, "stopPropagation");
+
+    fireEvent(likeButton, clickEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(stopPropagationSpy).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/cities/detail/CityDetailHero.test.tsx
+++ b/__tests__/components/cities/detail/CityDetailHero.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { City } from "@/lib/data";
+
+// --- Mocks -----------------------------------------------------------
+
+vi.mock("@/lib/ascii-art", () => ({
+  CITY_ASCII: {
+    jeju: "MOCK_JEJU_ASCII_ART",
+  } as Record<string, string>,
+}));
+
+vi.mock("@/components/ui/badge", () => ({
+  Badge: ({ children, ...props }: React.ComponentProps<"span">) => (
+    <span data-testid="badge" {...props}>
+      {children}
+    </span>
+  ),
+}));
+
+import CityDetailHero from "@/components/cities/detail/CityDetailHero";
+
+// --- Mock Data -------------------------------------------------------
+
+const mockCity: City = {
+  id: "jeju",
+  rank: 1,
+  name: "제주시",
+  nameEn: "JEJU",
+  region: "제주도",
+  score: 8.5,
+  monthlyCost: 1580000,
+  monthlyRent: 550000,
+  metrics: {
+    internet: 8.2,
+    cafe: 9.0,
+    transport: 7.5,
+    nature: 9.8,
+    nomadFriendly: 9.2,
+  },
+  tags: ["바다", "자연", "감성카페"],
+  environment: ["자연친화", "카페작업"],
+  budget: "100~200만원",
+  season: ["봄", "가을"],
+  likes: 128,
+  dislikes: 12,
+  internetSpeed: 82,
+  weather: "맑음 18°C",
+  aqi: 32,
+  symbol: "★",
+  mapX: 28,
+  mapY: 82,
+};
+
+const cityAqiBest: City = {
+  ...mockCity,
+  id: "gangneung",
+  name: "강릉시",
+  nameEn: "GANGNEUNG",
+  aqi: 25,
+};
+
+const cityAqiGood: City = {
+  ...mockCity,
+  id: "busan",
+  name: "부산시",
+  nameEn: "BUSAN",
+  aqi: 45,
+};
+
+const cityAqiNormal: City = {
+  ...mockCity,
+  id: "seoul",
+  name: "서울특별시",
+  nameEn: "SEOUL",
+  aqi: 60,
+};
+
+// --- Tests -----------------------------------------------------------
+
+describe("CityDetailHero", () => {
+  it("도시명(한글)과 영문명/지역이 렌더링된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("제주시")).toBeInTheDocument();
+    expect(screen.getByText("JEJU · 제주도")).toBeInTheDocument();
+  });
+
+  it("랭킹 뱃지(#N)가 표시된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("#1")).toBeInTheDocument();
+  });
+
+  it("종합 점수가 표시된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("8.5")).toBeInTheDocument();
+    // scoreToBlocks(8.5) => "████████▒░"
+    expect(screen.getByText("████████▒░")).toBeInTheDocument();
+  });
+
+  it("날씨 정보가 표시된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("맑음 18°C")).toBeInTheDocument();
+  });
+
+  describe("AQI 정보 및 범위별 텍스트", () => {
+    it("AQI <= 30 이면 값과 (최상) 텍스트가 표시된다", () => {
+      render(<CityDetailHero city={cityAqiBest} />);
+
+      expect(screen.getByText("25")).toBeInTheDocument();
+      expect(screen.getByText("(최상)")).toBeInTheDocument();
+    });
+
+    it("30 < AQI <= 50 이면 값과 (좋음) 텍스트가 표시된다", () => {
+      render(<CityDetailHero city={cityAqiGood} />);
+
+      expect(screen.getByText("45")).toBeInTheDocument();
+      expect(screen.getByText("(좋음)")).toBeInTheDocument();
+    });
+
+    it("AQI > 50 이면 값과 (보통) 텍스트가 표시된다", () => {
+      render(<CityDetailHero city={cityAqiNormal} />);
+
+      expect(screen.getByText("60")).toBeInTheDocument();
+      expect(screen.getByText("(보통)")).toBeInTheDocument();
+    });
+
+    it("mockCity(aqi=32)는 (좋음)으로 표시된다", () => {
+      render(<CityDetailHero city={mockCity} />);
+
+      expect(screen.getByText("32")).toBeInTheDocument();
+      expect(screen.getByText("(좋음)")).toBeInTheDocument();
+    });
+  });
+
+  it("태그들이 모두 렌더링된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    const badges = screen.getAllByTestId("badge");
+    expect(badges).toHaveLength(3);
+    expect(screen.getByText("바다")).toBeInTheDocument();
+    expect(screen.getByText("자연")).toBeInTheDocument();
+    expect(screen.getByText("감성카페")).toBeInTheDocument();
+  });
+
+  it("ASCII 아트가 렌더링된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("MOCK_JEJU_ASCII_ART")).toBeInTheDocument();
+  });
+
+  it("터미널 헤더(// CITY_PROFILE)가 표시된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("// CITY_PROFILE")).toBeInTheDocument();
+  });
+
+  it("파일명 헤더(city.id.dat)가 표시된다", () => {
+    render(<CityDetailHero city={mockCity} />);
+
+    expect(screen.getByText("jeju.dat")).toBeInTheDocument();
+  });
+
+  it("존재하지 않는 도시 ID의 경우 ASCII 아트가 빈 문자열이다", () => {
+    const unknownCity: City = {
+      ...mockCity,
+      id: "unknown-city",
+    };
+
+    const { container } = render(<CityDetailHero city={unknownCity} />);
+
+    const preElement = container.querySelector("pre");
+    expect(preElement).toBeInTheDocument();
+    expect(preElement!.textContent).toBe("");
+  });
+});

--- a/__tests__/components/cities/detail/CityInfoSection.test.tsx
+++ b/__tests__/components/cities/detail/CityInfoSection.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import CityInfoSection from "@/components/cities/detail/CityInfoSection";
+import { City } from "@/lib/data";
+
+const mockCity: City = {
+  id: "jeju",
+  rank: 1,
+  name: "제주시",
+  nameEn: "JEJU",
+  region: "제주도",
+  score: 8.5,
+  monthlyCost: 1580000,
+  monthlyRent: 550000,
+  metrics: { internet: 8.2, cafe: 9.0, transport: 7.5, nature: 9.8, nomadFriendly: 9.2 },
+  tags: ["바다", "자연", "감성카페"],
+  environment: ["자연친화", "카페작업"],
+  budget: "100~200만원",
+  season: ["봄", "가을"],
+  likes: 128,
+  dislikes: 12,
+  internetSpeed: 82,
+  weather: "맑음 18°C",
+  aqi: 32,
+  symbol: "★",
+  mapX: 28,
+  mapY: 82,
+};
+
+describe("CityInfoSection", () => {
+  // 1. 6개 라벨이 모두 렌더링되는지
+  it("renders all 6 info labels", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("월 생활비")).toBeInTheDocument();
+    expect(screen.getByText("원룸 월세")).toBeInTheDocument();
+    expect(screen.getByText("인터넷 속도")).toBeInTheDocument();
+    expect(screen.getByText("예산 분류")).toBeInTheDocument();
+    expect(screen.getByText("추천 계절")).toBeInTheDocument();
+    expect(screen.getByText("작업 환경")).toBeInTheDocument();
+  });
+
+  // 2. 월 생활비가 KRW 포맷으로 표시되는지
+  it("displays monthly cost in KRW format", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("₩1,580,000")).toBeInTheDocument();
+  });
+
+  // 3. 원룸 월세가 KRW 포맷으로 표시되는지
+  it("displays monthly rent in KRW format", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("₩550,000")).toBeInTheDocument();
+  });
+
+  // 4. 인터넷 속도가 Mbps 형식으로 표시되는지
+  it("displays internet speed in Mbps format", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("82Mbps")).toBeInTheDocument();
+  });
+
+  // 5. 예산 분류가 올바르게 표시되는지
+  it("displays budget category correctly", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("100~200만원")).toBeInTheDocument();
+  });
+
+  // 6. 추천 계절이 쉼표로 구분되어 표시되는지
+  it("displays recommended seasons joined by comma", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("봄, 가을")).toBeInTheDocument();
+  });
+
+  // 7. 작업 환경이 쉼표로 구분되어 표시되는지
+  it("displays work environments joined by comma", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("자연친화, 카페작업")).toBeInTheDocument();
+  });
+
+  // 8. // CITY_INFO 헤더가 표시되는지
+  it("renders the // CITY_INFO header", () => {
+    render(<CityInfoSection city={mockCity} />);
+
+    expect(screen.getByText("// CITY_INFO")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/cities/detail/CityMetricsSection.test.tsx
+++ b/__tests__/components/cities/detail/CityMetricsSection.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import CityMetricsSection from "@/components/cities/detail/CityMetricsSection";
+import { CityMetrics } from "@/lib/data";
+
+const mockMetrics: CityMetrics = {
+  internet: 8.2,
+  cafe: 9.0,
+  transport: 7.5,
+  nature: 9.8,
+  nomadFriendly: 9.2,
+};
+
+describe("CityMetricsSection", () => {
+  // 1. 5개 지표 라벨이 모두 렌더링되는지
+  it("renders all 5 metric labels", () => {
+    render(<CityMetricsSection metrics={mockMetrics} />);
+
+    expect(screen.getByText("인터넷")).toBeInTheDocument();
+    expect(screen.getByText("카페")).toBeInTheDocument();
+    expect(screen.getByText("교통")).toBeInTheDocument();
+    expect(screen.getByText("자연")).toBeInTheDocument();
+    expect(screen.getByText("노마드친화도")).toBeInTheDocument();
+  });
+
+  // 2. 각 지표의 숫자 값이 올바르게 표시되는지
+  it("displays correct numeric values for each metric", () => {
+    render(<CityMetricsSection metrics={mockMetrics} />);
+
+    expect(screen.getByText("8.2")).toBeInTheDocument();
+    expect(screen.getByText("9")).toBeInTheDocument();
+    expect(screen.getByText("7.5")).toBeInTheDocument();
+    expect(screen.getByText("9.8")).toBeInTheDocument();
+    expect(screen.getByText("9.2")).toBeInTheDocument();
+  });
+
+  // 3. // METRICS 헤더가 표시되는지
+  it("renders the // METRICS header", () => {
+    render(<CityMetricsSection metrics={mockMetrics} />);
+
+    expect(screen.getByText("// METRICS")).toBeInTheDocument();
+  });
+
+  // 4. 모든 아이콘이 표시되는지
+  it("displays all metric icons", () => {
+    render(<CityMetricsSection metrics={mockMetrics} />);
+
+    expect(screen.getByText("📡")).toBeInTheDocument();
+    expect(screen.getByText("☕")).toBeInTheDocument();
+    expect(screen.getByText("🚇")).toBeInTheDocument();
+    expect(screen.getByText("🌿")).toBeInTheDocument();
+    expect(screen.getByText("💻")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/cities/detail/CityReviewsSection.test.tsx
+++ b/__tests__/components/cities/detail/CityReviewsSection.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import CityReviewsSection from "@/components/cities/detail/CityReviewsSection";
+
+const MOCK_REVIEWS = vi.hoisted(() => [
+  { handle: "@user1", rating: 5, text: "최고의 도시!", cityName: "제주시", cityId: "jeju" },
+  { handle: "@user2", rating: 4, text: "좋아요", cityName: "제주시", cityId: "jeju" },
+  { handle: "@user3", rating: 3, text: "부산 괜찮아요", cityName: "부산", cityId: "busan" },
+]);
+
+vi.mock("@/lib/data", () => ({
+  REVIEWS: MOCK_REVIEWS,
+}));
+
+vi.mock("@/components/modals/ReviewModal", () => ({
+  default: ({ cityId, onClose }: { cityId: string | null; onClose: () => void }) => (
+    <div data-testid="review-modal" data-city-id={cityId} onClick={onClose}>
+      MockReviewModal
+    </div>
+  ),
+}));
+
+describe("CityReviewsSection", () => {
+  describe("리뷰 필터링 및 표시", () => {
+    it("해당 도시의 리뷰만 필터링하여 표시한다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      expect(screen.getByText("최고의 도시!")).toBeInTheDocument();
+      expect(screen.getByText("좋아요")).toBeInTheDocument();
+      expect(screen.queryByText("부산 괜찮아요")).not.toBeInTheDocument();
+    });
+
+    it("리뷰 개수가 헤더에 올바르게 표시된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      expect(screen.getByText("// REVIEWS (2)")).toBeInTheDocument();
+    });
+
+    it("리뷰가 1개인 도시의 리뷰 개수가 올바르게 표시된다", () => {
+      render(<CityReviewsSection cityId="busan" />);
+
+      expect(screen.getByText("// REVIEWS (1)")).toBeInTheDocument();
+      expect(screen.getByText("부산 괜찮아요")).toBeInTheDocument();
+    });
+  });
+
+  describe("리뷰가 없는 도시", () => {
+    it('리뷰가 없으면 "[ NO REVIEWS YET ]"이 표시된다', () => {
+      render(<CityReviewsSection cityId="seoul" />);
+
+      expect(screen.getByText("[ NO REVIEWS YET ]")).toBeInTheDocument();
+      expect(screen.getByText("첫 번째 리뷰를 작성해보세요")).toBeInTheDocument();
+    });
+
+    it("리뷰가 없으면 헤더에 개수가 0으로 표시된다", () => {
+      render(<CityReviewsSection cityId="seoul" />);
+
+      expect(screen.getByText("// REVIEWS (0)")).toBeInTheDocument();
+    });
+  });
+
+  describe("StarDisplay", () => {
+    it("rating 5인 리뷰는 별 5개 모두 활성화 색상으로 렌더링된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      // @user1의 rating은 5 - 모든 별이 활성화 색상(text-[#00FF88])이어야 함
+      const allStars = screen.getAllByText("★");
+      // jeju 리뷰 2개 (rating 5, rating 4) = 별 10개
+      expect(allStars).toHaveLength(10);
+
+      // 첫 번째 리뷰 (rating 5): 별 5개 모두 활성화
+      for (let i = 0; i < 5; i++) {
+        expect(allStars[i]).toHaveClass("text-[#00FF88]");
+      }
+    });
+
+    it("rating 4인 리뷰는 별 4개만 활성화 색상으로 렌더링된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      const allStars = screen.getAllByText("★");
+
+      // 두 번째 리뷰 (rating 4): 별 4개 활성화, 1개 비활성화
+      for (let i = 5; i < 9; i++) {
+        expect(allStars[i]).toHaveClass("text-[#00FF88]");
+      }
+      expect(allStars[9]).toHaveClass("text-[#333]");
+    });
+
+    it("rating 3인 리뷰는 별 3개만 활성화 색상으로 렌더링된다", () => {
+      render(<CityReviewsSection cityId="busan" />);
+
+      const allStars = screen.getAllByText("★");
+      expect(allStars).toHaveLength(5);
+
+      for (let i = 0; i < 3; i++) {
+        expect(allStars[i]).toHaveClass("text-[#00FF88]");
+      }
+      for (let i = 3; i < 5; i++) {
+        expect(allStars[i]).toHaveClass("text-[#333]");
+      }
+    });
+  });
+
+  describe("리뷰 정보 표시", () => {
+    it("리뷰 핸들(@user)이 표시된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      expect(screen.getByText("@user1")).toBeInTheDocument();
+      expect(screen.getByText("@user2")).toBeInTheDocument();
+    });
+
+    it("리뷰 텍스트가 표시된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      expect(screen.getByText("최고의 도시!")).toBeInTheDocument();
+      expect(screen.getByText("좋아요")).toBeInTheDocument();
+    });
+  });
+
+  describe("리뷰 작성 버튼 및 모달", () => {
+    it('"리뷰 작성" 버튼이 존재한다', () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      const button = screen.getByRole("button", { name: /리뷰 작성/ });
+      expect(button).toBeInTheDocument();
+    });
+
+    it("리뷰 작성 버튼 클릭 전에는 ReviewModal에 cityId가 null로 전달된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      const modal = screen.getByTestId("review-modal");
+      expect(modal).not.toHaveAttribute("data-city-id");
+    });
+
+    it("리뷰 작성 버튼 클릭 시 ReviewModal에 cityId가 전달된다", () => {
+      render(<CityReviewsSection cityId="jeju" />);
+
+      const button = screen.getByRole("button", { name: /리뷰 작성/ });
+      fireEvent.click(button);
+
+      const modal = screen.getByTestId("review-modal");
+      expect(modal).toHaveAttribute("data-city-id", "jeju");
+    });
+  });
+});

--- a/__tests__/components/cities/detail/CityVoteButtons.test.tsx
+++ b/__tests__/components/cities/detail/CityVoteButtons.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("lucide-react", () => ({
+  ThumbsUp: ({ size, ...props }: { size?: number }) => (
+    <span data-testid="thumbs-up" {...props} />
+  ),
+  ThumbsDown: ({ size, ...props }: { size?: number }) => (
+    <span data-testid="thumbs-down" {...props} />
+  ),
+}));
+
+import CityVoteButtons from "@/components/cities/detail/CityVoteButtons";
+
+describe("CityVoteButtons", () => {
+  const defaultProps = {
+    cityId: "city-1",
+    initialLikes: 10,
+    initialDislikes: 3,
+  };
+
+  // 1. 초기 렌더링: likes/dislikes 값이 올바르게 표시되는지
+  it("renders initial likes and dislikes counts", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  // 2. 좋아요 클릭: 좋아요 수가 1 증가하는지
+  it("increments likes by 1 when like button is clicked", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const likeButton = screen.getByText("10").closest("button")!;
+    fireEvent.click(likeButton);
+
+    expect(screen.getByText("11")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  // 3. 좋아요 다시 클릭(토글): 좋아요 수가 원래로 돌아가는지
+  it("decrements likes back to initial when like button is toggled", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const likeButton = screen.getByText("10").closest("button")!;
+    fireEvent.click(likeButton);
+    expect(screen.getByText("11")).toBeInTheDocument();
+
+    fireEvent.click(likeButton);
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  // 4. 싫어요 클릭: 싫어요 수가 1 증가하는지
+  it("increments dislikes by 1 when dislike button is clicked", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const dislikeButton = screen.getByText("3").closest("button")!;
+    fireEvent.click(dislikeButton);
+
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  // 5. 싫어요 다시 클릭(토글): 싫어요 수가 원래로 돌아가는지
+  it("decrements dislikes back to initial when dislike button is toggled", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const dislikeButton = screen.getByText("3").closest("button")!;
+    fireEvent.click(dislikeButton);
+    expect(screen.getByText("4")).toBeInTheDocument();
+
+    fireEvent.click(dislikeButton);
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  // 6. 좋아요 상태에서 싫어요 클릭: 좋아요 -1, 싫어요 +1 (상호 배타)
+  it("removes like and adds dislike when dislike is clicked while liked", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const likeButton = screen.getByText("10").closest("button")!;
+    fireEvent.click(likeButton);
+    expect(screen.getByText("11")).toBeInTheDocument();
+
+    const dislikeButton = screen.getByText("3").closest("button")!;
+    fireEvent.click(dislikeButton);
+
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  // 7. 싫어요 상태에서 좋아요 클릭: 싫어요 -1, 좋아요 +1 (상호 배타)
+  it("removes dislike and adds like when like is clicked while disliked", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const dislikeButton = screen.getByText("3").closest("button")!;
+    fireEvent.click(dislikeButton);
+    expect(screen.getByText("4")).toBeInTheDocument();
+
+    const likeButton = screen.getByText("10").closest("button")!;
+    fireEvent.click(likeButton);
+
+    expect(screen.getByText("11")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  // 8. 연속 클릭 시 상태가 올바른지
+  it("maintains correct state after a sequence of clicks", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    const likeButton = screen.getByText("10").closest("button")!;
+    const dislikeButton = screen.getByText("3").closest("button")!;
+
+    // 좋아요 클릭 -> likes: 11, dislikes: 3
+    fireEvent.click(likeButton);
+    expect(screen.getByText("11")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+
+    // 싫어요 클릭 (상호 배타) -> likes: 10, dislikes: 4
+    fireEvent.click(dislikeButton);
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+
+    // 싫어요 토글 해제 -> likes: 10, dislikes: 3
+    fireEvent.click(dislikeButton);
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+
+    // 좋아요 클릭 -> likes: 11, dislikes: 3
+    fireEvent.click(likeButton);
+    expect(screen.getByText("11")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+
+    // 좋아요 토글 해제 -> likes: 10, dislikes: 3
+    fireEvent.click(likeButton);
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  // 9. // VOTE 헤더가 렌더링되는지
+  it("renders the // VOTE header", () => {
+    render(<CityVoteButtons {...defaultProps} />);
+
+    expect(screen.getByText("// VOTE")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/data.test.ts
+++ b/__tests__/lib/data.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from "vitest";
+import {
+  scoreToBlocks,
+  metricToBlocks,
+  formatKRW,
+  formatKRWShort,
+  CITIES,
+} from "@/lib/data";
+import type { CityMetrics } from "@/lib/data";
+
+// ─── scoreToBlocks ──────────────────────────────────────────
+
+describe("scoreToBlocks", () => {
+  it("정수 점수 7 → 채워진 7칸 + 빈 3칸", () => {
+    expect(scoreToBlocks(7)).toBe("███████░░░");
+  });
+
+  it("소수 점수 >= 0.5 (7.5) → 채워진 7칸 + 반 1칸 + 빈 2칸", () => {
+    expect(scoreToBlocks(7.5)).toBe("███████▒░░");
+  });
+
+  it("소수 점수 < 0.5 (7.3) → 채워진 7칸 + 빈 3칸 (반 블록 없음)", () => {
+    expect(scoreToBlocks(7.3)).toBe("███████░░░");
+  });
+
+  it("최대값 10 → 모든 칸 채워짐", () => {
+    expect(scoreToBlocks(10)).toBe("██████████");
+  });
+
+  it("최소값 0 → 모든 칸 비어있음", () => {
+    expect(scoreToBlocks(0)).toBe("░░░░░░░░░░");
+  });
+
+  it("결과 문자열 길이는 항상 10 (filled + half + empty = 10)", () => {
+    const testValues = [0, 1, 2.3, 3.5, 4.9, 5, 6.5, 7.8, 8.5, 9.5, 10];
+    for (const value of testValues) {
+      const result = scoreToBlocks(value);
+      expect(result).toHaveLength(10);
+    }
+  });
+
+  it("정확히 0.5인 소수 부분은 반 블록으로 표시", () => {
+    expect(scoreToBlocks(0.5)).toBe("▒░░░░░░░░░");
+  });
+
+  it("0.49 소수 부분은 반 블록 없이 표시", () => {
+    expect(scoreToBlocks(0.49)).toBe("░░░░░░░░░░");
+  });
+
+  it("9.5 → 채워진 9칸 + 반 1칸", () => {
+    expect(scoreToBlocks(9.5)).toBe("█████████▒");
+  });
+
+  it("소수 부분이 정확히 0.99일 때 반 블록 표시", () => {
+    expect(scoreToBlocks(5.99)).toBe("█████▒░░░░");
+  });
+});
+
+// ─── metricToBlocks ─────────────────────────────────────────
+
+describe("metricToBlocks", () => {
+  it("정수 값 8 → 채워진 8칸 + 빈 2칸", () => {
+    expect(metricToBlocks(8)).toBe("████████░░");
+  });
+
+  it("소수 값 8.2 → 소수점 버림하여 채워진 8칸 + 빈 2칸", () => {
+    expect(metricToBlocks(8.2)).toBe("████████░░");
+  });
+
+  it("최대값 10 → 모든 칸 채워짐", () => {
+    expect(metricToBlocks(10)).toBe("██████████");
+  });
+
+  it("최소값 0 → 모든 칸 비어있음", () => {
+    expect(metricToBlocks(0)).toBe("░░░░░░░░░░");
+  });
+
+  it("결과 문자열 길이는 항상 10", () => {
+    const testValues = [0, 1, 2.3, 3.7, 4.99, 5, 6, 7.1, 8.9, 9, 10];
+    for (const value of testValues) {
+      const result = metricToBlocks(value);
+      expect(result).toHaveLength(10);
+    }
+  });
+
+  it("소수 값 9.9 → 소수점 버림하여 채워진 9칸 + 빈 1칸", () => {
+    expect(metricToBlocks(9.9)).toBe("█████████░");
+  });
+
+  it("소수 값 0.1 → 소수점 버림하여 빈 10칸", () => {
+    expect(metricToBlocks(0.1)).toBe("░░░░░░░░░░");
+  });
+});
+
+// ─── formatKRW ──────────────────────────────────────────────
+
+describe("formatKRW", () => {
+  it("일반 금액 1580000 → ₩ 접두사 + 천 단위 구분", () => {
+    const result = formatKRW(1580000);
+    expect(result).toBe("₩" + (1580000).toLocaleString("ko-KR"));
+  });
+
+  it("0 → ₩0", () => {
+    expect(formatKRW(0)).toBe("₩0");
+  });
+
+  it("큰 금액 2800000 → ₩ 접두사 + 천 단위 구분", () => {
+    const result = formatKRW(2800000);
+    expect(result).toBe("₩" + (2800000).toLocaleString("ko-KR"));
+  });
+
+  it("결과가 ₩ 접두사로 시작", () => {
+    expect(formatKRW(100)).toMatch(/^₩/);
+  });
+
+  it("작은 금액 100 → ₩100", () => {
+    expect(formatKRW(100)).toBe("₩100");
+  });
+});
+
+// ─── formatKRWShort ─────────────────────────────────────────
+
+describe("formatKRWShort", () => {
+  it("일반 금액 1580000 → ₩158만", () => {
+    expect(formatKRWShort(1580000)).toBe("₩158만");
+  });
+
+  it("반올림 확인: 1585000 → ₩159만 (올림)", () => {
+    expect(formatKRWShort(1585000)).toBe("₩159만");
+  });
+
+  it("작은 금액 980000 → ₩98만", () => {
+    expect(formatKRWShort(980000)).toBe("₩98만");
+  });
+
+  it("정확한 만 단위 1000000 → ₩100만", () => {
+    expect(formatKRWShort(1000000)).toBe("₩100만");
+  });
+
+  it("0 → ₩0만", () => {
+    expect(formatKRWShort(0)).toBe("₩0만");
+  });
+
+  it("반올림 경계값: 10004999 → ₩1000만 (버림)", () => {
+    expect(formatKRWShort(10004999)).toBe("₩1000만");
+  });
+
+  it("반올림 경계값: 10005000 → ₩1001만 (올림)", () => {
+    expect(formatKRWShort(10005000)).toBe("₩1001만");
+  });
+});
+
+// ─── CITIES 상수 ────────────────────────────────────────────
+
+describe("CITIES", () => {
+  it("7개 도시가 있어야 한다", () => {
+    expect(CITIES).toHaveLength(7);
+  });
+
+  it("각 도시에 고유한 id가 있어야 한다", () => {
+    const ids = CITIES.map((city) => city.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(CITIES.length);
+  });
+
+  it("각 도시에 고유한 rank가 있어야 한다", () => {
+    const ranks = CITIES.map((city) => city.rank);
+    const uniqueRanks = new Set(ranks);
+    expect(uniqueRanks.size).toBe(CITIES.length);
+  });
+
+  it("모든 도시에 필수 필드가 있어야 한다", () => {
+    const requiredKeys: (keyof (typeof CITIES)[0])[] = [
+      "id",
+      "rank",
+      "name",
+      "nameEn",
+      "region",
+      "score",
+      "monthlyCost",
+      "monthlyRent",
+      "metrics",
+      "tags",
+      "environment",
+      "budget",
+      "season",
+      "likes",
+      "dislikes",
+      "internetSpeed",
+      "weather",
+      "aqi",
+      "symbol",
+      "mapX",
+      "mapY",
+    ];
+
+    for (const city of CITIES) {
+      for (const key of requiredKeys) {
+        expect(city).toHaveProperty(key);
+      }
+    }
+  });
+
+  it("모든 도시의 score가 0-10 범위여야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.score).toBeGreaterThanOrEqual(0);
+      expect(city.score).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it("모든 도시의 metrics 각 항목이 0-10 범위여야 한다", () => {
+    const metricKeys: (keyof CityMetrics)[] = [
+      "internet",
+      "cafe",
+      "transport",
+      "nature",
+      "nomadFriendly",
+    ];
+
+    for (const city of CITIES) {
+      for (const key of metricKeys) {
+        expect(city.metrics[key]).toBeGreaterThanOrEqual(0);
+        expect(city.metrics[key]).toBeLessThanOrEqual(10);
+      }
+    }
+  });
+
+  it("모든 도시의 id는 빈 문자열이 아니어야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("모든 도시의 name은 빈 문자열이 아니어야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.name.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("모든 도시의 nameEn은 대문자로 구성되어야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.nameEn).toBe(city.nameEn.toUpperCase());
+    }
+  });
+
+  it("모든 도시의 monthlyCost가 양수여야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.monthlyCost).toBeGreaterThan(0);
+    }
+  });
+
+  it("모든 도시의 monthlyRent가 양수여야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.monthlyRent).toBeGreaterThan(0);
+    }
+  });
+
+  it("모든 도시에 최소 1개의 태그가 있어야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.tags.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("모든 도시에 최소 1개의 시즌이 있어야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.season.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("모든 도시에 최소 1개의 환경 유형이 있어야 한다", () => {
+    for (const city of CITIES) {
+      expect(city.environment.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("rank는 1부터 순차적으로 증가해야 한다", () => {
+    const ranks = CITIES.map((city) => city.rank).sort((a, b) => a - b);
+    for (let i = 0; i < ranks.length; i++) {
+      expect(ranks[i]).toBe(i + 1);
+    }
+  });
+
+  it("mapX와 mapY가 0-100 범위여야 한다 (퍼센트)", () => {
+    for (const city of CITIES) {
+      expect(city.mapX).toBeGreaterThanOrEqual(0);
+      expect(city.mapX).toBeLessThanOrEqual(100);
+      expect(city.mapY).toBeGreaterThanOrEqual(0);
+      expect(city.mapY).toBeLessThanOrEqual(100);
+    }
+  });
+});

--- a/app/cities/[id]/page.tsx
+++ b/app/cities/[id]/page.tsx
@@ -1,0 +1,63 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { CITIES } from "@/lib/data";
+import Navbar from "@/components/layout/Navbar";
+import Footer from "@/components/layout/Footer";
+import CityDetailHero from "@/components/cities/detail/CityDetailHero";
+import CityMetricsSection from "@/components/cities/detail/CityMetricsSection";
+import CityInfoSection from "@/components/cities/detail/CityInfoSection";
+import CityVoteButtons from "@/components/cities/detail/CityVoteButtons";
+import CityReviewsSection from "@/components/cities/detail/CityReviewsSection";
+
+interface CityDetailPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function CityDetailPage({ params }: CityDetailPageProps) {
+  const { id } = await params;
+  const city = CITIES.find((c) => c.id === id);
+
+  if (!city) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen bg-[#080808] flex flex-col">
+      <Navbar />
+
+      <main className="flex-1 mx-auto w-full max-w-3xl px-4 py-8">
+        {/* 뒤로가기 */}
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 font-mono text-xs text-gray-500 hover:text-[#00FF88] transition-colors mb-6"
+        >
+          <span>&larr;</span>
+          <span>BACK_TO_HOME</span>
+        </Link>
+
+        <div className="space-y-4">
+          {/* 히어로: ASCII 아트 + 도시 기본 정보 */}
+          <CityDetailHero city={city} />
+
+          {/* 지표 차트 */}
+          <CityMetricsSection metrics={city.metrics} />
+
+          {/* 도시 상세 정보 */}
+          <CityInfoSection city={city} />
+
+          {/* 좋아요/싫어요 */}
+          <CityVoteButtons
+            cityId={city.id}
+            initialLikes={city.likes}
+            initialDislikes={city.dislikes}
+          />
+
+          {/* 리뷰 */}
+          <CityReviewsSection cityId={city.id} />
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/components/cities/CityCard.tsx
+++ b/components/cities/CityCard.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { City } from "@/lib/data";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -25,70 +26,72 @@ const CITY_INFO_FIELDS: { label: string; getValue: (city: City) => string }[] = 
 
 export default function CityCard({ city, rank, liked, disliked, likes, dislikes, onLike, onDislike, onReview }: CityCardProps) {
   return (
-    <Card className="city-card bg-[#0f0f0f] border-[#222] flex flex-col w-72 shrink-0 overflow-hidden cursor-pointer">
-      {/* ASCII 아트 + 랭킹 */}
-      <CityAsciiArt cityId={city.id} rank={rank} />
+    <Link href={`/cities/${city.id}`} className="block">
+      <Card className="city-card bg-[#0f0f0f] border-[#222] flex flex-col w-72 shrink-0 overflow-hidden cursor-pointer">
+        {/* ASCII 아트 + 랭킹 */}
+        <CityAsciiArt cityId={city.id} rank={rank} />
 
-      {/* 도시명 */}
-      <div className="px-4 py-3 border-b border-[#1a1a1a]">
-        <div className="font-mono text-base font-bold text-white">{city.name}</div>
-        <div className="font-mono text-xs text-gray-500">
-          {city.nameEn} · {city.region}
+        {/* 도시명 */}
+        <div className="px-4 py-3 border-b border-[#1a1a1a]">
+          <div className="font-mono text-base font-bold text-white">{city.name}</div>
+          <div className="font-mono text-xs text-gray-500">
+            {city.nameEn} · {city.region}
+          </div>
+          <div className="flex gap-1.5 mt-2 flex-wrap">
+            {city.tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant="outline"
+                className="font-mono text-[10px] border-[#333] text-gray-500 px-1.5 py-0"
+              >
+                {tag}
+              </Badge>
+            ))}
+          </div>
         </div>
-        <div className="flex gap-1.5 mt-2 flex-wrap">
-          {city.tags.map((tag) => (
-            <Badge
-              key={tag}
-              variant="outline"
-              className="font-mono text-[10px] border-[#333] text-gray-500 px-1.5 py-0"
-            >
-              {tag}
-            </Badge>
+
+        {/* Key-Value 정보 */}
+        <div className="px-4 py-3 border-b border-[#1a1a1a] space-y-1.5">
+          {CITY_INFO_FIELDS.map(({ label, getValue }) => (
+            <div key={label} className="flex font-mono text-xs">
+              <span className="text-gray-500 w-20 shrink-0">{label}</span>
+              <span className="text-gray-300">{getValue(city)}</span>
+            </div>
           ))}
         </div>
-      </div>
 
-      {/* Key-Value 정보 */}
-      <div className="px-4 py-3 border-b border-[#1a1a1a] space-y-1.5">
-        {CITY_INFO_FIELDS.map(({ label, getValue }) => (
-          <div key={label} className="flex font-mono text-xs">
-            <span className="text-gray-500 w-20 shrink-0">{label}</span>
-            <span className="text-gray-300">{getValue(city)}</span>
-          </div>
-        ))}
-      </div>
-
-      {/* 액션 버튼 */}
-      <div className="px-4 py-3 flex gap-2">
-        <button
-          onClick={() => onLike(city.id)}
-          className={`flex-1 font-mono text-xs border py-1.5 transition-all flex items-center justify-center gap-1 ${
-            liked
-              ? "border-[#00FF88] text-[#00FF88]"
-              : "border-[#333] text-gray-400 hover:border-[#00FF88] hover:text-[#00FF88]"
-          }`}
-        >
-          <ThumbsUp size={12} />
-          {likes}
-        </button>
-        <button
-          onClick={() => onDislike(city.id)}
-          className={`flex-1 font-mono text-xs border py-1.5 transition-all flex items-center justify-center gap-1 ${
-            disliked
-              ? "border-red-500 text-red-400"
-              : "border-[#333] text-gray-400 hover:border-red-500 hover:text-red-400"
-          }`}
-        >
-          <ThumbsDown size={12} />
-          {dislikes}
-        </button>
-        <button
-          onClick={() => onReview?.(city.id)}
-          className="flex-1 font-mono text-xs border border-[#333] text-gray-400 hover:border-[#00E5FF] hover:text-[#00E5FF] py-1.5 transition-all"
-        >
-          ✎ 리뷰
-        </button>
-      </div>
-    </Card>
+        {/* 액션 버튼 */}
+        <div className="px-4 py-3 flex gap-2">
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onLike(city.id); }}
+            className={`flex-1 font-mono text-xs border py-1.5 transition-all flex items-center justify-center gap-1 ${
+              liked
+                ? "border-[#00FF88] text-[#00FF88]"
+                : "border-[#333] text-gray-400 hover:border-[#00FF88] hover:text-[#00FF88]"
+            }`}
+          >
+            <ThumbsUp size={12} />
+            {likes}
+          </button>
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onDislike(city.id); }}
+            className={`flex-1 font-mono text-xs border py-1.5 transition-all flex items-center justify-center gap-1 ${
+              disliked
+                ? "border-red-500 text-red-400"
+                : "border-[#333] text-gray-400 hover:border-red-500 hover:text-red-400"
+            }`}
+          >
+            <ThumbsDown size={12} />
+            {dislikes}
+          </button>
+          <button
+            onClick={(e) => { e.preventDefault(); e.stopPropagation(); onReview?.(city.id); }}
+            className="flex-1 font-mono text-xs border border-[#333] text-gray-400 hover:border-[#00E5FF] hover:text-[#00E5FF] py-1.5 transition-all"
+          >
+            ✎ 리뷰
+          </button>
+        </div>
+      </Card>
+    </Link>
   );
 }

--- a/components/cities/detail/CityDetailHero.tsx
+++ b/components/cities/detail/CityDetailHero.tsx
@@ -1,0 +1,104 @@
+import { City, scoreToBlocks } from "@/lib/data";
+import { CITY_ASCII } from "@/lib/ascii-art";
+import { Badge } from "@/components/ui/badge";
+
+interface CityDetailHeroProps {
+  city: City;
+}
+
+export default function CityDetailHero({ city }: CityDetailHeroProps) {
+  const ascii = CITY_ASCII[city.id] ?? "";
+
+  return (
+    <section className="border border-[#222] bg-[#0f0f0f]">
+      {/* 터미널 헤더 */}
+      <div className="px-5 py-2 border-b border-[#1a1a1a] flex items-center gap-2">
+        <span className="font-mono text-xs text-[#00FF88]">{"// CITY_PROFILE"}</span>
+        <span className="font-mono text-xs text-gray-600 ml-auto">
+          {city.id}.dat
+        </span>
+      </div>
+
+      {/* ASCII 아트 */}
+      <div className="relative bg-[#050505] border-b border-[#1a1a1a] p-6 overflow-hidden">
+        <pre
+          className="font-mono text-[#00FF88] leading-tight select-none text-center"
+          style={{ fontSize: "0.65rem", opacity: 0.8 }}
+          aria-hidden="true"
+        >
+          {ascii}
+        </pre>
+        {/* 랭킹 뱃지 */}
+        <div className="absolute top-3 right-3 font-mono text-sm font-bold text-[#080808] bg-[#00FF88] px-3 py-1">
+          #{city.rank}
+        </div>
+      </div>
+
+      {/* 도시 정보 */}
+      <div className="p-5 space-y-4">
+        {/* 도시명 */}
+        <div>
+          <h1 className="font-mono text-3xl font-bold text-white">
+            {city.name}
+          </h1>
+          <p className="font-mono text-sm text-gray-500 mt-1">
+            {city.nameEn} &middot; {city.region}
+          </p>
+        </div>
+
+        {/* 종합 점수 */}
+        <div className="flex items-center gap-3">
+          <span className="font-mono text-xs text-gray-500 w-20 shrink-0">
+            종합점수
+          </span>
+          <span className="font-mono text-sm text-[#00FF88] tracking-wider">
+            {scoreToBlocks(city.score)}
+          </span>
+          <span className="font-mono text-lg font-bold text-[#00FF88]">
+            {city.score}
+          </span>
+        </div>
+
+        {/* 날씨 + AQI */}
+        <div className="flex gap-6">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs text-gray-500">날씨</span>
+            <span className="font-mono text-sm text-gray-300">
+              {city.weather}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs text-gray-500">AQI</span>
+            <span
+              className={`font-mono text-sm font-bold ${
+                city.aqi <= 30
+                  ? "text-[#00FF88]"
+                  : city.aqi <= 50
+                    ? "text-yellow-400"
+                    : "text-orange-400"
+              }`}
+            >
+              {city.aqi}
+            </span>
+            <span className="font-mono text-xs text-gray-600">
+              {city.aqi <= 30 ? "(최상)" : city.aqi <= 50 ? "(좋음)" : "(보통)"}
+            </span>
+          </div>
+        </div>
+
+        {/* 태그 */}
+        <div className="flex gap-2 flex-wrap">
+          {city.tags.map((tag) => (
+            <Badge
+              key={tag}
+              variant="outline"
+              className="font-mono text-xs border-[#333] text-gray-400 px-2 py-0.5"
+            >
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/cities/detail/CityInfoSection.tsx
+++ b/components/cities/detail/CityInfoSection.tsx
@@ -1,0 +1,34 @@
+import { City, formatKRW } from "@/lib/data";
+
+interface CityInfoSectionProps {
+  city: City;
+}
+
+const INFO_FIELDS: { label: string; getValue: (city: City) => string }[] = [
+  { label: "월 생활비", getValue: (city) => formatKRW(city.monthlyCost) },
+  { label: "원룸 월세", getValue: (city) => formatKRW(city.monthlyRent) },
+  { label: "인터넷 속도", getValue: (city) => `${city.internetSpeed}Mbps` },
+  { label: "예산 분류", getValue: (city) => city.budget },
+  { label: "추천 계절", getValue: (city) => city.season.join(", ") },
+  { label: "작업 환경", getValue: (city) => city.environment.join(", ") },
+];
+
+export default function CityInfoSection({ city }: CityInfoSectionProps) {
+  return (
+    <section className="border border-[#222] bg-[#0f0f0f]">
+      {/* 터미널 헤더 */}
+      <div className="px-5 py-2 border-b border-[#1a1a1a]">
+        <span className="font-mono text-xs text-[#00FF88]">{"// CITY_INFO"}</span>
+      </div>
+
+      <div className="p-5 space-y-3">
+        {INFO_FIELDS.map(({ label, getValue }) => (
+          <div key={label} className="flex font-mono text-sm">
+            <span className="text-gray-500 w-28 shrink-0">{label}</span>
+            <span className="text-gray-300">{getValue(city)}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/cities/detail/CityMetricsSection.tsx
+++ b/components/cities/detail/CityMetricsSection.tsx
@@ -1,0 +1,41 @@
+import { CityMetrics, metricToBlocks } from "@/lib/data";
+
+interface CityMetricsSectionProps {
+  metrics: CityMetrics;
+}
+
+const METRIC_LABELS: { key: keyof CityMetrics; label: string; icon: string }[] = [
+  { key: "internet", label: "인터넷", icon: "📡" },
+  { key: "cafe", label: "카페", icon: "☕" },
+  { key: "transport", label: "교통", icon: "🚇" },
+  { key: "nature", label: "자연", icon: "🌿" },
+  { key: "nomadFriendly", label: "노마드친화도", icon: "💻" },
+];
+
+export default function CityMetricsSection({ metrics }: CityMetricsSectionProps) {
+  return (
+    <section className="border border-[#222] bg-[#0f0f0f]">
+      {/* 터미널 헤더 */}
+      <div className="px-5 py-2 border-b border-[#1a1a1a]">
+        <span className="font-mono text-xs text-[#00FF88]">{"// METRICS"}</span>
+      </div>
+
+      <div className="p-5 space-y-3">
+        {METRIC_LABELS.map(({ key, label, icon }) => (
+          <div key={key} className="flex items-center gap-3">
+            <span className="text-sm">{icon}</span>
+            <span className="font-mono text-xs text-gray-500 w-24 shrink-0">
+              {label}
+            </span>
+            <span className="font-mono text-sm text-[#00E5FF] tracking-wider flex-1">
+              {metricToBlocks(metrics[key])}
+            </span>
+            <span className="font-mono text-sm font-bold text-white w-8 text-right">
+              {metrics[key]}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/cities/detail/CityReviewsSection.tsx
+++ b/components/cities/detail/CityReviewsSection.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { REVIEWS } from "@/lib/data";
+import ReviewModal from "@/components/modals/ReviewModal";
+
+interface CityReviewsSectionProps {
+  cityId: string;
+}
+
+function StarDisplay({ rating }: { rating: number }) {
+  return (
+    <span className="font-mono text-sm">
+      {Array.from({ length: 5 }, (_, i) => (
+        <span
+          key={i}
+          className={i < rating ? "text-[#00FF88]" : "text-[#333]"}
+        >
+          ★
+        </span>
+      ))}
+    </span>
+  );
+}
+
+export default function CityReviewsSection({ cityId }: CityReviewsSectionProps) {
+  const [reviewModalOpen, setReviewModalOpen] = useState(false);
+  const cityReviews = REVIEWS.filter((r) => r.cityId === cityId);
+
+  return (
+    <section className="border border-[#222] bg-[#0f0f0f]">
+      {/* 터미널 헤더 */}
+      <div className="px-5 py-2 border-b border-[#1a1a1a] flex items-center justify-between">
+        <span className="font-mono text-xs text-[#00FF88]">
+          {"// REVIEWS ("}{cityReviews.length}{")"}
+        </span>
+        <button
+          onClick={() => setReviewModalOpen(true)}
+          className="font-mono text-xs border border-[#333] text-gray-400 hover:border-[#00E5FF] hover:text-[#00E5FF] px-3 py-1 transition-all"
+        >
+          ✎ 리뷰 작성
+        </button>
+      </div>
+
+      <div className="p-5">
+        {cityReviews.length > 0 ? (
+          <div className="space-y-4">
+            {cityReviews.map((review, index) => (
+              <div
+                key={index}
+                className="border-b border-[#1a1a1a] pb-4 last:border-b-0 last:pb-0"
+              >
+                <div className="flex items-center gap-3 mb-2">
+                  <StarDisplay rating={review.rating} />
+                  <span className="font-mono text-xs text-[#00E5FF]">
+                    {review.handle}
+                  </span>
+                </div>
+                <p className="font-mono text-sm text-gray-300 leading-relaxed">
+                  {review.text}
+                </p>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-8">
+            <p className="font-mono text-sm text-gray-600">
+              [ NO REVIEWS YET ]
+            </p>
+            <p className="font-mono text-xs text-gray-700 mt-1">
+              첫 번째 리뷰를 작성해보세요
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* 리뷰 모달 */}
+      <ReviewModal
+        cityId={reviewModalOpen ? cityId : null}
+        onClose={() => setReviewModalOpen(false)}
+      />
+    </section>
+  );
+}

--- a/components/cities/detail/CityVoteButtons.tsx
+++ b/components/cities/detail/CityVoteButtons.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
+
+interface CityVoteButtonsProps {
+  cityId: string;
+  initialLikes: number;
+  initialDislikes: number;
+}
+
+export default function CityVoteButtons({
+  initialLikes,
+  initialDislikes,
+}: CityVoteButtonsProps) {
+  const [liked, setLiked] = useState(false);
+  const [disliked, setDisliked] = useState(false);
+  const [likes, setLikes] = useState(initialLikes);
+  const [dislikes, setDislikes] = useState(initialDislikes);
+
+  const handleLike = () => {
+    if (liked) {
+      setLiked(false);
+      setLikes((prev) => prev - 1);
+    } else {
+      setLiked(true);
+      setLikes((prev) => prev + 1);
+      if (disliked) {
+        setDisliked(false);
+        setDislikes((prev) => prev - 1);
+      }
+    }
+  };
+
+  const handleDislike = () => {
+    if (disliked) {
+      setDisliked(false);
+      setDislikes((prev) => prev - 1);
+    } else {
+      setDisliked(true);
+      setDislikes((prev) => prev + 1);
+      if (liked) {
+        setLiked(false);
+        setLikes((prev) => prev - 1);
+      }
+    }
+  };
+
+  return (
+    <section className="border border-[#222] bg-[#0f0f0f]">
+      {/* 터미널 헤더 */}
+      <div className="px-5 py-2 border-b border-[#1a1a1a]">
+        <span className="font-mono text-xs text-[#00FF88]">{"// VOTE"}</span>
+      </div>
+
+      <div className="p-5 flex gap-3">
+        <button
+          onClick={handleLike}
+          className={`flex-1 font-mono text-sm border py-3 transition-all flex items-center justify-center gap-2 ${
+            liked
+              ? "border-[#00FF88] text-[#00FF88] bg-[rgba(0,255,136,0.05)]"
+              : "border-[#333] text-gray-400 hover:border-[#00FF88] hover:text-[#00FF88]"
+          }`}
+        >
+          <ThumbsUp size={16} />
+          <span>{likes}</span>
+        </button>
+        <button
+          onClick={handleDislike}
+          className={`flex-1 font-mono text-sm border py-3 transition-all flex items-center justify-center gap-2 ${
+            disliked
+              ? "border-red-500 text-red-400 bg-[rgba(239,68,68,0.05)]"
+              : "border-[#333] text-gray-400 hover:border-red-500 hover:text-red-400"
+          }`}
+        >
+          <ThumbsDown size={16} />
+          <span>{dislikes}</span>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,16 +21,35 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^5.1.4",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jsdom": "^28.1.0",
         "shadcn": "^3.8.5",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "5.9.3",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -67,6 +86,64 @@
         "nup": "bin/nup.mjs"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -98,6 +175,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -412,6 +490,38 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
@@ -450,6 +560,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -498,6 +618,153 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -657,6 +924,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -743,6 +1011,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -887,6 +1597,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1842,6 +2570,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3449,6 +4178,363 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3475,6 +4561,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.98.0",
@@ -3570,6 +4663,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.98.0.tgz",
       "integrity": "sha512-Ohc97CtInLwZyiSASz7tT9/Abm/vqnIbO9REp+PivVUII8UZsuI3bngRQnYgJdFoOIwvaEII1fX1qy8x0CyNiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.98.0",
         "@supabase/functions-js": "2.98.0",
@@ -3861,6 +4955,91 @@
         "tailwindcss": "4.2.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
@@ -3953,6 +5132,76 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3993,8 +5242,9 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4003,8 +5253,9 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4077,6 +5328,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -4596,6 +5848,138 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
+      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.29.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.18.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4616,6 +6000,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4930,6 +6315,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -5015,6 +6410,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -5084,6 +6489,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5203,6 +6609,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -5520,6 +6936,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5533,11 +6970,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
+      "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5555,6 +7018,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/data-view-buffer": {
@@ -5628,6 +7105,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.1",
@@ -5750,6 +7234,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5788,6 +7282,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -5878,6 +7379,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6017,6 +7531,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -6077,6 +7598,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -6113,6 +7676,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6298,6 +7862,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6541,6 +8106,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6611,12 +8186,23 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6940,6 +8526,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7346,8 +8947,22 @@
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -7369,6 +8984,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -7456,6 +9085,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -7881,6 +9520,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -8158,6 +9804,48 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -8670,6 +10358,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8689,6 +10387,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -8792,6 +10497,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -9254,6 +10969,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -9478,6 +11204,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9526,6 +11265,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -9633,6 +11379,51 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
@@ -9855,6 +11646,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9864,6 +11656,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9877,6 +11670,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -9962,6 +11765,20 @@
       },
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -10104,6 +11921,51 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -10230,6 +12092,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -10609,6 +12484,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -10655,6 +12537,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -10664,6 +12553,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -10894,6 +12790,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -10956,6 +12865,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -11004,6 +12920,13 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -11058,11 +12981,22 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -11119,6 +13053,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11315,6 +13262,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11364,6 +13312,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -11570,6 +13528,218 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -11578,6 +13748,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -11683,6 +13888,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -11799,6 +14021,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -11936,6 +14175,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -22,14 +22,19 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^5.1.4",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^28.1.0",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./vitest.setup.ts"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- 도시 카드 클릭 시 `/cities/[id]` 상세 페이지로 이동하는 기능 구현
- 히어로(ASCII 아트, 도시명, 랭킹, 점수, 날씨, AQI, 태그), 핵심 지표(블록 차트), 생활 정보, 좋아요/싫어요 투표, 리뷰 섹션 총 5개 섹션 컴포넌트 구현
- CityCard에 Next.js Link 추가 및 버튼 이벤트 버블링 방지

## Changes
| 파일 | 변경 유형 |
|------|----------|
| `app/cities/[id]/page.tsx` | 신규 - 서버 컴포넌트 (notFound 처리 포함) |
| `components/cities/CityCard.tsx` | 수정 - Link 래핑 + stopPropagation |
| `components/cities/detail/CityDetailHero.tsx` | 신규 - 히어로 섹션 |
| `components/cities/detail/CityMetricsSection.tsx` | 신규 - 핵심 지표 섹션 |
| `components/cities/detail/CityInfoSection.tsx` | 신규 - 생활 정보 섹션 |
| `components/cities/detail/CityVoteButtons.tsx` | 신규 - 좋아요/싫어요 클라이언트 컴포넌트 |
| `components/cities/detail/CityReviewsSection.tsx` | 신규 - 리뷰 섹션 (ReviewModal 재사용) |

## Test plan
- [x] Vitest + Testing Library 기반 유닛 테스트 100개 작성 및 통과
- [x] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [x] ESLint 린트 통과
- [ ] `/cities/jeju`, `/cities/busan` 등 도시 ID로 직접 접근 가능 확인
- [ ] 존재하지 않는 도시 ID 접근 시 404 페이지 표시 확인
- [ ] 홈 페이지 도시 카드 클릭 시 상세 페이지로 정상 이동 확인
- [ ] 상세 페이지에서 모든 섹션이 렌더링됨 확인
- [ ] 뒤로가기 링크로 홈 페이지 복귀 가능 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)